### PR TITLE
added support for escapes in tags

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -78,6 +78,23 @@ export default class GPTPlugin extends Plugin {
     errorGettingCompletionNotice();
   }
 
+  formatTag(escaped: string): string {
+    return escaped.replace(/\\[\\rnt]/g, function(matched: string): string {
+      switch (matched) {
+        // this doesn't cover all escapes, but is very safe
+        case "\\\\": return "\\";
+        case "\\r": return "\r";
+        case "\\n": return "\n";
+        case "\\t": return "\t";
+      }
+      return matched;
+    })
+  }
+  
+  trimLines(raw: string): string {
+    return raw.replace(/^[\n\r]+|[\n\r]+$/g, '')
+  }
+
   formatCompletion(prompt: string, completion: string) {
     const {
       tagCompletions,
@@ -87,11 +104,11 @@ export default class GPTPlugin extends Plugin {
     } = this.settings;
 
     if (tagCompletions) {
-      completion = `${tagCompletionsHandlerTags.openingTag}${completion}${tagCompletionsHandlerTags.closingTag}`;
+      completion = `${this.formatTag(tagCompletionsHandlerTags.openingTag)}${this.trimLines(completion)}${this.formatTag(tagCompletionsHandlerTags.closingTag)}`;
     }
 
     if (tagPrompts) {
-      prompt = `${tagPromptsHandlerTags.openingTag}${prompt}${tagPromptsHandlerTags.closingTag}`;
+      prompt = `${this.formatTag(tagPromptsHandlerTags.openingTag)}${prompt}${this.formatTag(tagPromptsHandlerTags.closingTag)}`;
     }
 
     return prompt + completion;


### PR DESCRIPTION
I tried to improve the ability to format the GPT output, for example I use these settings:

![image](https://user-images.githubusercontent.com/817160/215275010-537632af-6114-4b70-967c-fbcb99371c5a.png)

resulting in output like:

![image](https://user-images.githubusercontent.com/817160/215275059-720f5185-e733-40d2-b4b7-11f8a985c897.png)

Since I am not a typescript guy, the code may be terrible, but could at least serve as inspiration for such a feature.  So hack it up all you want and I won't be offended :)